### PR TITLE
add support for dictionary field type as pyarrow map array

### DIFF
--- a/src/pydantic_to_pyarrow/schema.py
+++ b/src/pydantic_to_pyarrow/schema.py
@@ -111,10 +111,21 @@ def _get_annotated_type(
     return _get_pyarrow_type(field_type, metadata, allow_losing_tz)
 
 
+def _get_dict_type(
+    field_type: Type[Any], metadata: List[Any], allow_losing_tz: bool
+) -> pa.DataType:
+    key_type, value_type = get_args(field_type)
+    return pa.map_(
+        _get_pyarrow_type(key_type, [], allow_losing_tz=False),
+        _get_pyarrow_type(value_type, [], allow_losing_tz=False),
+    )
+
+
 FIELD_TYPES = {
     Literal: _get_literal_type,
     list: _get_list_type,
     Annotated: _get_annotated_type,
+    dict: _get_dict_type,
 }
 
 

--- a/src/pydantic_to_pyarrow/schema.py
+++ b/src/pydantic_to_pyarrow/schema.py
@@ -116,8 +116,8 @@ def _get_dict_type(
 ) -> pa.DataType:
     key_type, value_type = get_args(field_type)
     return pa.map_(
-        _get_pyarrow_type(key_type, [], allow_losing_tz=False),
-        _get_pyarrow_type(value_type, [], allow_losing_tz=False),
+        _get_pyarrow_type(key_type, metadata, allow_losing_tz=allow_losing_tz),
+        _get_pyarrow_type(value_type, metadata, allow_losing_tz=allow_losing_tz),
     )
 
 


### PR DESCRIPTION
## issue

Need support for python's `dictionary` type to convert pydantic object to pyarrow.

e.g.

```python
MyModel(BaseModel):
    foo: Dict[str, str]

get_pyarrow_schema(MyModel)
```

## change

If a pydantic field is defined as a `Dict`, convert to `pyarrow.MapType` [[definition](https://arrow.apache.org/docs/python/generated/pyarrow.MapType.html)]. 

MapType is the closest pyarrow data type to the Dict type. However, it will convert to a tuple upon deserialization (from pyarrow to vanilla python).
https://arrow.apache.org/docs/python/data.html#map-arrays

note: this is a rather naive approach. open to suggestions... by default, pyarrow will try to use `pyarrow.StructScalar`. However, this will not work if inferring the schema of a Dict of unknown size. 

## test

assert the additional logic makes sense. assert the new test case passes.