### PR TITLE
(postponed, requires upstream fix) add support for UUID

### DIFF
--- a/src/pydantic_to_pyarrow/schema.py
+++ b/src/pydantic_to_pyarrow/schema.py
@@ -1,5 +1,6 @@
 import datetime
 import types
+import uuid
 from decimal import Decimal
 from enum import EnumMeta
 from typing import Any, List, Literal, NamedTuple, Optional, Type, TypeVar, Union, cast
@@ -31,6 +32,7 @@ FIELD_MAP = {
     datetime.date: pa.date32(),
     NaiveDatetime: pa.timestamp("ms", tz=None),
     datetime.time: pa.time64("us"),
+    uuid.UUID: pa.uuid(),
 }
 
 # Timezone aware datetimes will lose their timezone information


### PR DESCRIPTION
By default pydantic's UUID fields are serialized as UUID objects by `model_dump`

This does not work well with pyarrow, which does not support UUID objects but instead a byte representation of them (which can be obtained with `my_uuid.bytes`).

In the tests, I've added annotated the types with serializers to convert the UUID objects as bytes.

Not sure this is the way to go, though