### PR TITLE
Allow for arbitrary types to be converted to pa.binary()

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,23 @@ Enum of str | pa.dictionary(pa.int32(), pa.string()) |
 Enum of int | pa.int64() |
 UUID (uuid.UUID or pydantic.types.UUID*) | pa.uuid() | SEE NOTE BELOW!
 
-Note on UUIDs: the UUID type is only supported in pyarrow 18.0 and above. However,
+By default, all other types will produce a SchemaCreationError. However, if you want
+other types to be converted to pa.binary(), then you have two options:
+
+- Set `model_config = ConfigDict(arbitrary_types_allowed=True)` on the model. As well
+as making pydantic accept arbitrary types, this will make this library convert
+those arbitrary types (and other types this library does not understand) to `pa.binary()`.
+- Call `get_pyarrow_schema` with `arbitrary_types_allowed=True`. This case will cover
+types that regular pydantic understands but that this library does not know how
+to convert (yet).
+
+If either of those are True, then arbitrary types will be converted to pa.binary() fields.
+To force no conversion to `pa.binary()`, then call `get_pyarrow_schema` with
+`arbitrary_types_allowed=False`.
+
+### Note on UUIDs
+
+The UUID type is only supported in pyarrow 18.0 and above. However,
 as of pyarrow 19.0, when pyarrow creates a table in eg `pa.Table.from_pylist(objs, schema=schema)`,
 it expects bytes not a uuid.UUID type. Hence, if you are using .model_dump() to create
 the data for pyarrow, you need to add a serializer on your pydantic model to convert to bytes.

--- a/src/pydantic_to_pyarrow/__init__.py
+++ b/src/pydantic_to_pyarrow/__init__.py
@@ -1,6 +1,6 @@
 from .schema import SchemaCreationError, get_pyarrow_schema
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 __all__ = [
     "__version__",

--- a/src/pydantic_to_pyarrow/schema.py
+++ b/src/pydantic_to_pyarrow/schema.py
@@ -1,7 +1,6 @@
 import datetime
 import types
 import uuid
-from collections import defaultdict
 from decimal import Decimal
 from enum import EnumMeta
 from typing import Any, List, Literal, NamedTuple, Optional, Type, TypeVar, Union, cast
@@ -23,20 +22,18 @@ class Settings(NamedTuple):
     allow_losing_tz: bool
     by_alias: bool
     exclude_fields: bool
+    arbitrary_types_allowed: bool
 
 
-FIELD_MAP = defaultdict(
-    lambda: pa.binary(),
-    {
-        str: pa.string(),
-        bytes: pa.binary(),
-        bool: pa.bool_(),
-        float: pa.float64(),
-        datetime.date: pa.date32(),
-        NaiveDatetime: pa.timestamp("ms", tz=None),
-        datetime.time: pa.time64("us"),
-    }
-)
+FIELD_MAP = {
+    str: pa.string(),
+    bytes: pa.binary(),
+    bool: pa.bool_(),
+    float: pa.float64(),
+    datetime.date: pa.date32(),
+    NaiveDatetime: pa.timestamp("ms", tz=None),
+    datetime.time: pa.time64("us"),
+}
 
 # Timezone aware datetimes will lose their timezone information
 # (but be correctly converted to UTC) when converted to pyarrow.
@@ -88,6 +85,7 @@ def _get_literal_type(
     field_type: Type[Any],
     _metadata: List[Any],
     _settings: Settings,
+    _arbitrary_types_allowed: bool,
 ) -> pa.DataType:
     values = get_args(field_type)
     if all(isinstance(value, str) for value in values):
@@ -105,18 +103,22 @@ def _get_list_type(
     field_type: Type[Any],
     metadata: List[Any],
     settings: Settings,
+    arbitrary_types_allowed: bool,
 ) -> pa.DataType:
     sub_type = get_args(field_type)[0]
     if _is_optional(sub_type):
         # pyarrow lists can have null elements in them
         sub_type = list(set(get_args(sub_type)) - {type(None)})[0]
-    return pa.list_(_get_pyarrow_type(sub_type, metadata, settings))
+    return pa.list_(
+        _get_pyarrow_type(sub_type, metadata, settings, arbitrary_types_allowed)
+    )
 
 
 def _get_annotated_type(
     field_type: Type[Any],
     metadata: List[Any],
     settings: Settings,
+    arbitrary_types_allowed: bool,
 ) -> pa.DataType:
     # TODO: fix / clean up / understand why / if this works in all cases
     args = get_args(field_type)[1:]
@@ -125,18 +127,19 @@ def _get_annotated_type(
     ]
     metadata = [item for sublist in metadatas for item in sublist]
     field_type = cast(Type[Any], get_args(field_type)[0])
-    return _get_pyarrow_type(field_type, metadata, settings)
+    return _get_pyarrow_type(field_type, metadata, settings, arbitrary_types_allowed)
 
 
 def _get_dict_type(
     field_type: Type[Any],
     metadata: List[Any],
     settings: Settings,
+    arbitrary_types_allowed: bool,
 ) -> pa.DataType:
     key_type, value_type = get_args(field_type)
     return pa.map_(
-        _get_pyarrow_type(key_type, metadata, settings),
-        _get_pyarrow_type(value_type, metadata, settings),
+        _get_pyarrow_type(key_type, metadata, settings, arbitrary_types_allowed),
+        _get_pyarrow_type(value_type, metadata, settings, arbitrary_types_allowed),
     )
 
 
@@ -190,6 +193,7 @@ def _get_pyarrow_type(  # noqa: PLR0911
     field_type: Type[Any],
     metadata: List[Any],
     settings: Settings,
+    arbitrary_types_allowed: bool,
 ) -> pa.DataType:
     if field_type is uuid.UUID:
         return _get_uuid_type()
@@ -213,12 +217,18 @@ def _get_pyarrow_type(  # noqa: PLR0911
             field_type,
             metadata,
             settings,
+            arbitrary_types_allowed,
         )
 
     # isinstance(filed_type, type) checks whether it's a class
     # otherwise eg Deque[int] would casue an exception on issubclass
     if isinstance(field_type, type) and issubclass(field_type, BaseModel):
         return _get_pyarrow_schema(field_type, settings, as_schema=False)
+
+    if field_type not in FIELD_MAP and (
+        arbitrary_types_allowed or settings.arbitrary_types_allowed
+    ):
+        return pa.binary()
 
     return FIELD_MAP[field_type]
 
@@ -229,6 +239,9 @@ def _get_pyarrow_schema(
     as_schema: bool = True,
 ) -> pa.Schema:
     fields = []
+    arbitrary_types_allowed = pydantic_class.model_config.get(
+        "arbitrary_types_allowed", False
+    )
     for name, field_info in pydantic_class.model_fields.items():
         if field_info.exclude and settings.exclude_fields:
             continue
@@ -249,7 +262,9 @@ def _get_pyarrow_schema(
                 # mypy infers field_type as Type[Any] | None here, hence casting
                 field_type = cast(Type[Any], types_under_union[0])
 
-            pa_field = _get_pyarrow_type(field_type, metadata, settings)
+            pa_field = _get_pyarrow_type(
+                field_type, metadata, settings, arbitrary_types_allowed
+            )
         except Exception as err:  # noqa: BLE001 - ignore blind exception
             raise SchemaCreationError(
                 f"Error processing field {name}: {field_type}, {err}"
@@ -270,6 +285,7 @@ def get_pyarrow_schema(
     allow_losing_tz: bool = False,
     exclude_fields: bool = False,
     by_alias: bool = False,
+    arbitrary_types_allowed: bool = False,
 ) -> pa.Schema:
     """
     Converts a Pydantic model into a PyArrow schema.
@@ -282,6 +298,11 @@ def get_pyarrow_schema(
             model that have `Field(exclude=True)`. Defaults to False.
         by_alias (bool, optional): If True, will create the pyarrow schema using the
             (serialization) alias in the pydantic model. Defaults to False.
+        arbitrary_types_allowed (bool, optional): If True, then all unknown types
+            will be converted to binary. Defaults to False. This is similar to the
+            effect of setting model_config arbitrary_types_allowed=True, except
+            that it will now apply across all types that this library does not
+            understand.
 
     Returns:
         pa.Schema: The PyArrow schema representing the Pydantic model.
@@ -290,5 +311,6 @@ def get_pyarrow_schema(
         allow_losing_tz=allow_losing_tz,
         by_alias=by_alias,
         exclude_fields=exclude_fields,
+        arbitrary_types_allowed=arbitrary_types_allowed,
     )
     return _get_pyarrow_schema(pydantic_class, settings)

--- a/src/pydantic_to_pyarrow/schema.py
+++ b/src/pydantic_to_pyarrow/schema.py
@@ -22,7 +22,7 @@ class Settings(NamedTuple):
     allow_losing_tz: bool
     by_alias: bool
     exclude_fields: bool
-    arbitrary_types_allowed: bool
+    arbitrary_types_allowed: Optional[bool]
 
 
 FIELD_MAP = {
@@ -225,9 +225,10 @@ def _get_pyarrow_type(  # noqa: PLR0911
     if isinstance(field_type, type) and issubclass(field_type, BaseModel):
         return _get_pyarrow_schema(field_type, settings, as_schema=False)
 
-    if field_type not in FIELD_MAP and (
-        arbitrary_types_allowed or settings.arbitrary_types_allowed
-    ):
+    convert_to_binary = settings.arbitrary_types_allowed or (
+        settings.arbitrary_types_allowed is None and arbitrary_types_allowed
+    )
+    if field_type not in FIELD_MAP and convert_to_binary:
         return pa.binary()
 
     return FIELD_MAP[field_type]
@@ -285,7 +286,7 @@ def get_pyarrow_schema(
     allow_losing_tz: bool = False,
     exclude_fields: bool = False,
     by_alias: bool = False,
-    arbitrary_types_allowed: bool = False,
+    arbitrary_types_allowed: Optional[bool] = None,
 ) -> pa.Schema:
     """
     Converts a Pydantic model into a PyArrow schema.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -13,24 +13,9 @@ import pytest
 from annotated_types import Gt
 from packaging import version
 from pydantic import BaseModel, ConfigDict, Field, PlainSerializer
-from pydantic.types import (
-    UUID1,
-    UUID3,
-    UUID4,
-    UUID5,
-    AwareDatetime,
-    NaiveDatetime,
-    PositiveInt,
-    StrictBool,
-    StrictBytes,
-    StrictFloat,
-    StrictInt,
-    StrictStr,
-    condecimal,
-)
-from typing_extensions import Annotated
-
+from pydantic.types import UUID1, UUID3, UUID4, UUID5, AwareDatetime, NaiveDatetime, PositiveInt, StrictBool, StrictBytes, StrictFloat, StrictInt, StrictStr, condecimal  # NOQA
 from pydantic_to_pyarrow import SchemaCreationError, get_pyarrow_schema
+from typing_extensions import Annotated
 
 
 def _write_pq_and_read(
@@ -112,9 +97,8 @@ def test_unknown_type() -> None:
     class SimpleModel(BaseModel):
         a: Deque[int]
 
-    with pytest.raises(SchemaCreationError) as err:
-        get_pyarrow_schema(SimpleModel)
-    assert "Unknown type" in str(err)
+    schema = get_pyarrow_schema(SimpleModel)
+    assert schema.field('a').type == pa.binary()
 
 
 def test_positive_ints() -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -120,11 +120,20 @@ def test_unknown_type() -> None:
 def test_unknown_type_with_model_arbitrary_types_allowed() -> None:
     class SimpleModel(BaseModel):
         model_config = ConfigDict(arbitrary_types_allowed=True)
-
         a: Deque[int]
 
     schema = get_pyarrow_schema(SimpleModel)
     assert schema.field("a").type == pa.binary()
+
+
+def test_unknown_type_global_setting_overrides_config() -> None:
+    class SimpleModel(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+        a: Deque[int]
+
+    with pytest.raises(SchemaCreationError) as err:
+        get_pyarrow_schema(SimpleModel, arbitrary_types_allowed=False)
+    assert "Deque[int]" in str(err)
 
 
 def test_unknown_type_with_global_arbitrary_types_allowed() -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -13,9 +13,24 @@ import pytest
 from annotated_types import Gt
 from packaging import version
 from pydantic import BaseModel, ConfigDict, Field, PlainSerializer
-from pydantic.types import UUID1, UUID3, UUID4, UUID5, AwareDatetime, NaiveDatetime, PositiveInt, StrictBool, StrictBytes, StrictFloat, StrictInt, StrictStr, condecimal  # NOQA
-from pydantic_to_pyarrow import SchemaCreationError, get_pyarrow_schema
+from pydantic.types import (
+    UUID1,
+    UUID3,
+    UUID4,
+    UUID5,
+    AwareDatetime,
+    NaiveDatetime,
+    PositiveInt,
+    StrictBool,
+    StrictBytes,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+    condecimal,
+)  # NOQA
 from typing_extensions import Annotated
+
+from pydantic_to_pyarrow import SchemaCreationError, get_pyarrow_schema
 
 
 def _write_pq_and_read(
@@ -97,8 +112,27 @@ def test_unknown_type() -> None:
     class SimpleModel(BaseModel):
         a: Deque[int]
 
+    with pytest.raises(SchemaCreationError) as err:
+        get_pyarrow_schema(SimpleModel)
+    assert "Deque[int]" in str(err)
+
+
+def test_unknown_type_with_model_arbitrary_types_allowed() -> None:
+    class SimpleModel(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        a: Deque[int]
+
     schema = get_pyarrow_schema(SimpleModel)
-    assert schema.field('a').type == pa.binary()
+    assert schema.field("a").type == pa.binary()
+
+
+def test_unknown_type_with_global_arbitrary_types_allowed() -> None:
+    class SimpleModel(BaseModel):
+        a: Deque[int]
+
+    schema = get_pyarrow_schema(SimpleModel, arbitrary_types_allowed=True)
+    assert schema.field("a").type == pa.binary()
 
 
 def test_positive_ints() -> None:


### PR DESCRIPTION
There are 2 cases where arbitrary types (those that would otherwise cause a SchemaCreationError) are wanted to be turned into pa.binary() fields:

1. When the pydnatic model_config has arbitrary_types_allowed=True. In this case, the clear user intent is that arbitrary types are wanted - and so this library defaults to converting them to pa.binary()
2. When the global setting arbitrary_types_allowed is set to True. This forces all field types that would otherwise have not been recognized (and caused a SchemaCreationError) to be converted to pa.binary().