### PR TITLE
Add support for computed fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ of timezone-aware python datetimes to non-timezone aware pyarrow timestamps
 (defaults to False - and loss of timezone information will raise an exception).
 
 By default, `get_pyarrow_schema` will use the field names for the pyarrow schema fields. If
-`by_alias=True` is supplied, then the serialization_alias is used. More information about aliases is available in the [Pydantic documentation](https://docs.pydantic.dev/latest/concepts/alias/).
+`by_alias=True` is supplied, then the serialization_alias is used (or `alias` for computed fields). More information about aliases is available in the [Pydantic documentation](https://docs.pydantic.dev/latest/concepts/alias/).
 
 ## An Example
 

--- a/src/pydantic_to_pyarrow/schema.py
+++ b/src/pydantic_to_pyarrow/schema.py
@@ -3,11 +3,13 @@ import types
 import uuid
 from decimal import Decimal
 from enum import EnumMeta
+from itertools import chain
 from typing import Any, List, Literal, NamedTuple, Optional, Type, TypeVar, Union, cast
 
 import pyarrow as pa  # type: ignore
 from annotated_types import Ge, Gt
 from pydantic import AwareDatetime, BaseModel, NaiveDatetime
+from pydantic.fields import ComputedFieldInfo
 from typing_extensions import Annotated, get_args, get_origin
 
 BaseModelType = TypeVar("BaseModelType", bound=BaseModel)
@@ -228,17 +230,27 @@ def _get_pyarrow_schema(
     as_schema: bool = True,
 ) -> pa.Schema:
     fields = []
-    for name, field_info in pydantic_class.model_fields.items():
-        if field_info.exclude and settings.exclude_fields:
-            continue
-        field_type = field_info.annotation
-        metadata = field_info.metadata
 
-        if field_type is None:
+    for name, field_info in chain(
+        pydantic_class.model_fields.items(),
+        pydantic_class.model_computed_fields.items(),
+    ):
+        is_computed = isinstance(field_info, ComputedFieldInfo)
+
+        if not is_computed and field_info.exclude and settings.exclude_fields:
+            continue
+
+        if is_computed:
+            field_type = field_info.return_type
+            metadata: List[Any] = []
+        else:
+            field_type = field_info.annotation
+            metadata = field_info.metadata
+
+        if field_type is None:  # pragma: no cover
             # Not sure how to get here through pydantic, hence nocover
-            raise SchemaCreationError(
-                f"Missing type for field {name}"
-            )  # pragma: no cover
+            field_kind = "computed field" if is_computed else "field"
+            raise SchemaCreationError(f"Missing type for {field_kind} {name}")
 
         try:
             nullable = False
@@ -250,13 +262,21 @@ def _get_pyarrow_schema(
 
             pa_field = _get_pyarrow_type(field_type, metadata, settings)
         except Exception as err:  # noqa: BLE001 - ignore blind exception
+            field_kind = "computed field" if is_computed else "field"
             raise SchemaCreationError(
-                f"Error processing field {name}: {field_type}, {err}"
+                f"Error processing {field_kind} {name}: {field_type}, {err}"
             ) from err
 
         serialized_name = name
-        if settings.by_alias and field_info.serialization_alias is not None:
-            serialized_name = field_info.serialization_alias
+        if settings.by_alias:
+            alias = (
+                field_info.alias
+                if is_computed
+                else field_info.serialization_alias
+            )
+            if alias is not None:
+                serialized_name = alias
+
         fields.append(pa.field(serialized_name, pa_field, nullable=nullable))
 
     if as_schema:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -12,7 +12,7 @@ import pydantic
 import pytest
 from annotated_types import Gt
 from packaging import version
-from pydantic import BaseModel, ConfigDict, Field, PlainSerializer
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer, computed_field
 from pydantic.types import (
     UUID1,
     UUID3,
@@ -739,3 +739,57 @@ def test_alias_generator() -> None:
 
     actual_by_alias = get_pyarrow_schema(AliasModel, by_alias=True)
     assert actual_by_alias == expected_by_alias
+
+
+def test_computed_field_decimal() -> None:
+    class ComputedModel(BaseModel):
+        num: Annotated[Decimal, Field(max_digits=10, decimal_places=2)]
+
+        @computed_field
+        @property
+        def num_doubled(
+            self,
+        ) -> Annotated[Decimal, Field(max_digits=10, decimal_places=2)]:
+            return self.num * 2
+
+    expected = pa.schema(
+        [
+            pa.field("num", pa.decimal128(10, 2), nullable=False),
+            pa.field("num_doubled", pa.decimal128(10, 2), nullable=False),
+        ]
+    )
+
+    actual = get_pyarrow_schema(ComputedModel)
+    assert actual == expected
+
+
+def test_computed_field() -> None:
+    class ComputedByAliasModel(BaseModel):
+        model_config = ConfigDict(alias_generator=lambda field_name: field_name.upper())
+        name: str
+        value: int
+
+        @computed_field
+        @property
+        def upper_name(self) -> str:
+            return self.name.upper()
+
+    expected_no_alias = pa.schema(
+        [
+            pa.field("name", pa.string(), nullable=False),
+            pa.field("value", pa.int64(), nullable=False),
+            pa.field("upper_name", pa.string(), nullable=False),
+        ]
+    )
+    actual_no_alias = get_pyarrow_schema(ComputedByAliasModel, by_alias=False)
+    assert actual_no_alias == expected_no_alias
+
+    expected_alias = pa.schema(
+        [
+            pa.field("NAME", pa.string(), nullable=False),
+            pa.field("VALUE", pa.int64(), nullable=False),
+            pa.field("UPPER_NAME", pa.string(), nullable=False),
+        ]
+    )
+    actual_alias = get_pyarrow_schema(ComputedByAliasModel, by_alias=True)
+    assert actual_alias == expected_alias


### PR DESCRIPTION
This adds support for creating pyarrow schemas from models that include [computed fields](https://docs.pydantic.dev/latest/concepts/fields/#the-computed_field-decorator).